### PR TITLE
add alternative dns servers.

### DIFF
--- a/src/RecursiveProvider.php
+++ b/src/RecursiveProvider.php
@@ -5,7 +5,7 @@ namespace yswery\DNS;
 use \Exception;
 
 class RecursiveProvider extends AbstractStorageProvider {
-    
+
     private $dns_answer_names = array(
         'DNS_A' => 'ip',
         'DNS_AAAA' => 'ipv6',
@@ -16,31 +16,49 @@ class RecursiveProvider extends AbstractStorageProvider {
         'DNS_SOA' => array('mname', 'rname', 'serial', 'retry', 'refresh', 'expire', 'minimum-ttl'),
         'DNS_PTR' => 'target',
     );
-    
+
+    private $servers = array();
+    private $serverpicker = -1;
+
+    public function __construct(array $servers = array(), callable $serverpicker = null) {
+        $this->servers = $servers;
+        if($serverpicker == null){
+            $this->serverpicker = function(){return -1;};
+        }else{
+            $this->serverpicker = $serverpicker;
+        }
+    }
+
     public function get_answer($question)
     {
         $answer = array();
         $domain = trim($question[0]['qname'], '.');
         $type = RecordTypeEnum::get_name($question[0]['qtype']);
-        
+
         $records = $this->get_records_recursivly($domain, $type);
         foreach($records as $record) {
             $answer[] = array('name' => $question[0]['qname'], 'class' => $question[0]['qclass'], 'ttl' => $record['ttl'], 'data' => array('type' => $question[0]['qtype'], 'value' => $record['answer']));
         }
-     
+
         return $answer;
     }
-    
+
     private function get_records_recursivly($domain, $type)
     {
+
         $result = array();
-        $dns_const_name =  $this->get_dns_cost_name($type);
-        
-        if (!$dns_const_name) {
-           throw new Exception('Not supported dns type to query.'); 
+        $result = $this->try_configured_servers($domain, $type);
+        if(!empty($result)){
+            return $result;
         }
-        
+        $dns_const_name =  $this->get_dns_cost_name($type);
+
+        if (!$dns_const_name) {
+            return $result; //why throw error? if the provider does not support it, just return nothing, otherwise the service is down.
+        }
+
         $dns_answer_name = $this->dns_answer_names[$dns_const_name];
+
         $records = dns_get_record($domain, constant($dns_const_name));
 
         foreach($records as $record) {
@@ -56,14 +74,55 @@ class RecursiveProvider extends AbstractStorageProvider {
 
         return $result;
     }
-    
+
+    private function try_configured_servers($domain, $type){
+        $response = array();
+        $servers = $this->servers;
+        $select = call_user_func_array($this->serverpicker, array($domain, $type));
+        if($select && array_key_exists($select,$servers)){
+            $response = $this->dig($domain,$type, $servers[$select]);
+            unset($servers[$select]);
+        }
+        if(empty($response) && !empty($servers)){
+            foreach($servers as $server) {
+                $response = $this->dig($domain,$type, $server);
+                if($response){
+                    return $response;
+                }
+            }
+        }
+        return $response;
+    }
+
+    private function dig($domain,$type,$server){
+        $line = exec(escapeshellcmd("dig +nocmd +noall +answer +time=1 +tries=1 -t $type @$server $domain"), $response);
+        $result = array();
+        if(strstr($line, "connection timed out")===false) {
+            foreach ($response as $value) {
+                $value = preg_split('/\s+/', $value);
+                array_filter($value);
+                switch (strtoupper($type)) {
+                    case "MX": $result[] = array_combine(array("domain", "ttl", "class", "type", "priority", "answer"), $value);
+                        break;
+                    case "SOA": $value = array_combine(array("domain", "ttl", "IN", "class", "mname", "rname","serial","retry","refresh","expire" ,"minimum-ttl"), $value);
+                                $result[] = array("answer"=>$value, "ttl"=>$value["ttl"]);
+                        break;
+                    default: $result[] = array_combine(array("domain", "ttl", "class", "type", "answer"), $value);
+                        break;
+                }
+            }
+            return $result;
+        }
+        return array();
+    }
+
     private function get_dns_cost_name($type)
     {
         $const_name = "DNS_".strtoupper($type);
         $name = defined($const_name) ? $const_name : false;
-        
+
         return $name;
     }
-    
+
 }
 

--- a/src/RecursiveProvider.php
+++ b/src/RecursiveProvider.php
@@ -37,7 +37,7 @@ class RecursiveProvider extends AbstractStorageProvider {
 
         $records = $this->get_records_recursivly($domain, $type);
         foreach($records as $record) {
-            $answer[] = array('name' => $question[0]['qname'], 'class' => $question[0]['qclass'], 'ttl' => $record['ttl'], 'data' => array('type' => $question[0]['qtype'], 'value' => $record['answer']));
+            $answer[] = array('name' => (isset($record["domain"])?$record["domain"]:$question[0]['qname']), 'class' => $question[0]['qclass'], 'ttl' => $record['ttl'], 'data' => array('type' => (isset($record['type'])?RecordTypeEnum::get_type_index($record['type']):$question[0]['qtype']), 'value' => $record['answer']));
         }
 
         return $answer;
@@ -54,7 +54,7 @@ class RecursiveProvider extends AbstractStorageProvider {
         $dns_const_name =  $this->get_dns_cost_name($type);
 
         if (!$dns_const_name) {
-            return $result; //why throw error? if the provider does not support it, just return nothing, otherwise the service is down.
+            throw new Exception('Not supported dns type to query.');
         }
 
         $dns_answer_name = $this->dns_answer_names[$dns_const_name];

--- a/src/Server.php
+++ b/src/Server.php
@@ -62,6 +62,8 @@ class Server {
 
     private function ds_handle_query($buffer, $ip, $port)
     {
+	$_SERVER['client_ip'] = $ip;
+	$_SERVER['client_port'] = $port;
         $data = unpack('npacket_id/nflags/nqdcount/nancount/nnscount/narcount', $buffer);
         $flags = $this->ds_decode_flags($data['flags']);
         $offset = 12;


### PR DESCRIPTION
added some support for alternative dns servers other than defined in the dns server. requires execute rights for the dig command. also a callable can be used to pick a server (similar to what unblockus.com does).

If not supplied, the provider still works the same as it used before.
