### PR TITLE
Improved test configuration.

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,8 +1,24 @@
-<phpunit bootstrap="tests/bootstrap.php">
-    <testsuite name="dns-server-tests">
-        <directory suffix="Test.php">tests</directory>
-    </testsuite>
-    <logging>
-        <log type="coverage-clover" target="tests/clover.xml"/>
-    </logging>
+<?xml version="1.0" encoding="UTF-8"?>
+    <phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.3/phpunit.xsd"
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    syntaxCheck="false"
+    bootstrap="vendor/autoload.php"
+    >
+        <testsuites>
+            <testsuite name="YSWERY PHP DNS Server">
+                <directory>./tests</directory>
+            </testsuite>
+        </testsuites>
+        <logging>
+            <log type="coverage-clover" target="tests/clover.xml"/>
+        </logging>
 </phpunit>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,3 +1,0 @@
-<?php
-
-require __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
I changed the `phpunit.xml` file so that it would bootstrap the composer autoload file instead of `tests/bootstrap.php`, thus I could remove the now redundant bootstrap file.