### PR TITLE
Added tests for the server class.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     "require": {},
     "autoload": {
         "psr-4": {
-            "yswery\\DNS\\": "src/"
+            "yswery\\DNS\\": "src/",
+            "yswery\\DNS\\Tests\\": "tests/"
         }
     }
 }

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -1,0 +1,40 @@
+<?php
+/*
+ * This file is part of PHP DNS Server.
+ *
+ * (c) Yif Swery <yiftachswr@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace yswery\DNS\Tests;
+
+class ServerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var TestServerProxy
+     */
+    private $server;
+
+    public function setUp()
+    {
+        $this->server = new TestServerProxy;
+    }
+
+    public function testDs_encode_label()
+    {
+        $input_1 = 'www.example.com.';
+        $expectation_1 = chr(3) . 'www' . chr(7) . 'example' . chr(3) . 'com' . "\0";
+
+        $input_2 = '.';
+        $expectation_2 = "\0";
+
+        $input_3 = 'tld.';
+        $expectation_3 = chr(3) . 'tld' . "\0";
+
+        $this->assertEquals($expectation_1, $this->server->ds_encode_label($input_1));
+        $this->assertEquals($expectation_2, $this->server->ds_encode_label($input_2));
+        $this->assertEquals($expectation_3, $this->server->ds_encode_label($input_3));
+    }
+}

--- a/tests/TestServerProxy.php
+++ b/tests/TestServerProxy.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ * This file is part of PHP DNS Server.
+ *
+ * (c) Yif Swery <yiftachswr@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace yswery\DNS\Tests;
+
+use yswery\DNS\Server;
+use yswery\DNS\JsonStorageProvider;
+
+class TestServerProxy
+{
+    private static $name = 'yswery\DNS\Server';
+
+    /**
+     * @var Server
+     */
+    protected $server;
+
+    public function __construct()
+    {
+        $storage = new JsonStorageProvider(__DIR__ . '/test_records.json');
+        $this->server = new Server($storage);
+    }
+
+    public function ds_encode_label($str, $offset = null)
+    {
+        $method = new \ReflectionMethod(self::$name, 'ds_encode_label');
+        $method->setAccessible(true);
+
+        return $method->invoke($this->server, $str, $offset);
+    }
+}


### PR DESCRIPTION
Started on creating unit tests for the Server class. Since pretty much all the methods are private, I have proxied the Server class in order to access the methods directly.

This is not an ideal solution, but it enables deeper testing (and therefore safer refactoring) without hacking the API.

As I raised in issue #23, it would be better to separate the encoder and decoder methods.