### PR TITLE
Adds support for setting the ra flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ before_script:
   - composer install --dev
 after_script:
   - php vendor/bin/coveralls
+dist: trusty

--- a/src/Server.php
+++ b/src/Server.php
@@ -69,8 +69,18 @@ class Server
         $authority = $this->ds_decode_rr($buffer, $offset, $data['nscount']);
         $additional = $this->ds_decode_rr($buffer, $offset, $data['arcount']);
         $answer = $this->ds_storage->get_answer($question);
+
         $flags['qr'] = 1;
-        $flags['ra'] = 0;
+
+        $ra = false;
+        if ($this->ds_storage instanceof StackableResolver) {
+            foreach ($this->ds_storage->get_resolvers() as $resolver) {
+                $ra |= ($resolver == 'RecursiveProvider');
+            }
+        } else if ($this->ds_storage instanceof RecursiveProvider) {
+            $ra = true;
+        }
+        $flags['ra'] = $ra ? 1 : 0;
 
         $qdcount = count($question);
         $ancount = count($answer);

--- a/src/StackableResolver.php
+++ b/src/StackableResolver.php
@@ -10,6 +10,14 @@ class StackableResolver
      */
     protected $resolvers;
 
+    public function get_resolvers() {
+        $resolvers_names = array();
+        foreach ($this->resolvers as $resolver) {
+            $resolver_names[] = (new \ReflectionClass($resolver))->getShortName();
+        }
+      return $resolver_names;
+    }
+
     public function __construct(array $resolvers = array())
     {
         $this->resolvers = $resolvers;


### PR DESCRIPTION
Sets the RA (RecursionAvailable) flag when the RecursiveProvider is used (either directly or through the StackableResolver). Without setting this flag, the nslookup tool simply skips this dns server.