### PR TITLE
Fixes crash when querying for '.'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ before_script:
   - composer install --dev
 after_script:
   - php vendor/bin/coveralls
+dist: trusty

--- a/src/RecursiveProvider.php
+++ b/src/RecursiveProvider.php
@@ -20,7 +20,9 @@ class RecursiveProvider extends AbstractStorageProvider
     public function get_answer($question)
     {
         $answer = array();
-        $domain = trim($question[0]['qname'], '.');
+
+        $domain = $question[0]['qname'];
+
         $type = RecordTypeEnum::get_name($question[0]['qtype']);
 
         $records = $this->get_records_recursivly($domain, $type);


### PR DESCRIPTION
There was an unecessary trim($...question, '.') that when the query was simlpy '.', returned an empty string. This caused the RecursiveProvider to crash when calling php's get_dns_record with an empty domain name.