### PR TITLE
Updated documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,13 @@ $server->start();
 
 Query server using `dig` command to ensure proper functioning
 ```bash
-$ dig @127.0.0.1 test.com A +short
+$ dig @127.0.0.1 test.com A +short +noedns
 111.111.111.111
 
-$ dig @127.0.0.1 test.com TXT +short
+$ dig @127.0.0.1 test.com TXT +short +noedns
 "Some text."
 
-$ dig @127.0.0.1 test2.com A +short
+$ dig @127.0.0.1 test2.com A +short +noedns
 111.111.111.111
 112.112.112.112
 ```

--- a/docs/events.md
+++ b/docs/events.md
@@ -38,7 +38,7 @@ $eventDispatcher = new \Symfony\Component\EventDispatcher\EventDispatcher();
 $eventDispatcher->addSubscriber(new ExampleEventSubscriber());
 $server = new Server(new JsonResolver('./record.json'), $eventDispatcher);
 ```
-##Supported events
+## Supported events
 
 * `Events::SERVER_START` - Server is started and listening for queries.
 * `Events::SERVER_EXCEPTION` - Exception is thrown when processing and responding to query.


### PR DESCRIPTION
dig has EDNS enabled by default so running our previous examples would result in request timeout on client and error: Record type "OPT" is not a supported type in server logs. Added +noedns flag to dig query in examples to make them work until we add support for OPT queries.