### PR TITLE
Adds more dns record types

### DIFF
--- a/src/RecursiveResolver.php
+++ b/src/RecursiveResolver.php
@@ -12,12 +12,19 @@ class RecursiveResolver implements ResolverInterface
     private $dns_answer_names = array(
         'DNS_A' => 'ip',
         'DNS_AAAA' => 'ipv6',
+	'DNS_A6' => array('masklen', 'ipv6', 'chain'),
+	/* 'DNS_ALL' => '', */
+	/* 'DNS_ANY' => '', */
         'DNS_CNAME' => 'target',
-        'DNS_TXT' => 'txt',
+	'DNS_CAA' => array('flags', 'tag', 'value'),
+	'DNS_HINFO' => array('cpu', 'os'),
         'DNS_MX' => 'target',
+	'DNS_NAPTR' => array('order', 'pref'),
         'DNS_NS' => 'target',
-        'DNS_SOA' => array('mname', 'rname', 'serial', 'retry', 'refresh', 'expire', 'minimum-ttl'),
         'DNS_PTR' => 'target',
+        'DNS_SOA' => array('mname', 'rname', 'serial', 'retry', 'refresh', 'expire', 'minimum-ttl'),
+	'DNS_SRV' => array('pri', 'weight', 'target', 'port'),
+        'DNS_TXT' => 'txt',
     );
 
     public function getAnswer(array $question)


### PR DESCRIPTION
I encountered a crash in the following situation.

I have php-dns running on one server. On another server that resolves via the first, I run `apt-get update`. On the first server, `php-dns` crashed with the error:

```
"Undefined index: DNS_SRV" in file "/usr/lib/php-dns/vendor/yswery/dns/src/RecursiveResolver.php" on line "48"
```

I added to the dns answers all the records that are mentioned in the (PHP documentation)[https://secure.php.net/manual/en/function.dns-get-record.php] but were missing from php-dns.