### PR TITLE
PhpDnsServer phar and cli phar

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,25 @@ Unit tests using PHPUnit are provided. A simple script is located in the root.
 * run `composer install` to install PHPUnit and dependencies
 * run `vendor/bin/phpunit` from the root to run the tests
 
+## Building .phar
+* run `composer run-script build-server` to build the phpdnsserver.phar file, outputs in the bin folder.
+* run `composer run-script build-console` to build the phpdnscli.phar file, outputs in the bin folder.
+* run  `composer run-script build-installer` to build the installer. Windows support for the installer is currently limited.
+
+## Running the .phar files
+To run the new .phar files, download them from the release and move them to the desired folder.
+* `phpdnsserver.phar` to run the phpdnsserver, uses the new filesystem by default
+* `phpdnscli.phar` to run cli commands
+* `phpdnsinstaller.phar` as root to create required folders and default config.
+
+## Supported command line switches
+* `--bind:b` - bind to a specific ip. Uses `0.0.0.0` by default
+* `--port:p` - bind to a specific port. Uses port `53` by default
+* `--config:c` - specify the config file. Uses `phpdns.json` on windows 
+and `/etc/phpdns.json` on unix systems by default
+* `--storage:s` - specify the path to the storage for zones, and logs. Uses `/etc/phpdnsserver` on unix,
+and current working directory on windows.
+
 ## Supported Record Types
 
 * A

--- a/bin/PhpDnsConsole.php
+++ b/bin/PhpDnsConsole.php
@@ -1,0 +1,13 @@
+<?php
+
+require '../vendor/autoload.php';
+
+// Create the eventDispatcher and add the event subscribers
+$eventDispatcher = new \Symfony\Component\EventDispatcher\EventDispatcher();
+$eventDispatcher->addSubscriber(new \yswery\DNS\Event\Subscriber\EchoLogger());
+
+// Create a new instance of Server class
+$server = new yswery\DNS\Console\CommandServer();
+
+// Start DNS server
+$server->run();

--- a/bin/PhpDnsInstaller.php
+++ b/bin/PhpDnsInstaller.php
@@ -1,0 +1,65 @@
+<?php
+
+require '../vendor/autoload.php';
+
+echo "Preparing installation of PhpDnsServer.\n";
+
+// detect os
+if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+    $isWindows = true;
+    echo "Detected windows environment, please note that running the installer on windows is not fully supported at this time.";
+} else {
+    $isWindows = false;
+}
+
+// make sure we are running as root if os is linux
+if (!$isWindows) {
+    if (posix_getuid() != 0) {
+        die("This script must be run as root.\n");
+    }
+
+    // create the default config file
+    $defaultConfig = [
+        'host' => '0.0.0.0',
+        'port' => 53,
+        'storage' => '/etc/phpdnsserver',
+        'backend' => 'file'
+    ];
+
+    $filesystem = new \Symfony\Component\Filesystem\Filesystem;
+
+    try {
+        echo "Creating required directories and config files...\n";
+
+        $filesystem->mkdir('/etc/phpdnsserver');
+        $filesystem->mkdir('/etc/phpdnsserver/zones');
+        $filesystem->mkdir('/etc/phpdnsserver/logs');
+
+        // create default config
+        file_put_contents('/etc/phpdns.json', json_encode(getcwd()));
+    } catch (\Symfony\Component\Filesystem\Exception\IOException $e){
+        die("An error occurred during installation\n".$e->getMessage());
+    }
+
+} else {
+    // create the default config file
+    $defaultConfig = [
+        'host' => '0.0.0.0',
+        'port' => 53,
+        'backend' => 'file'
+    ];
+
+    $filesystem = new \Symfony\Component\Filesystem\Filesystem;
+
+    try {
+        echo "Creating required directories and config files...\n";
+
+        $filesystem->mkdir(getcwd().'\\zones');
+        $filesystem->mkdir(getcwd().'\\logs');
+
+        // create default config
+        file_put_contents(getcwd().'\\phpdns.json', json_encode(getcwd()));
+    } catch (\Symfony\Component\Filesystem\Exception\IOException $e){
+        die("An error occurred during installation\n".$e->getMessage());
+    }
+}

--- a/bin/PhpDnsServer.php
+++ b/bin/PhpDnsServer.php
@@ -4,11 +4,14 @@ require '../vendor/autoload.php';
 
 use Garden\Cli\Cli;
 
+// parse cli args
 $cli = new Cli();
 
 $cli
     ->opt('bind:b', 'Bind to a specific ip interface', false)
-    ->opt('port:p', 'specify the port to bind to', false);
+    ->opt('port:p', 'specify the port to bind to', false)
+    ->opt('config:c', 'specify the path to the phpdns.json file', false)
+    ->opt('storage:s', 'specify the location to zone storage folder', false);
 
 $args = $cli->parse($argv, true);
 
@@ -16,15 +19,47 @@ $args = $cli->parse($argv, true);
 $host = $args->getOpt('bind', '0.0.0.0');
 $port = $args->getOpt('port', 53);
 
+// figure out config location
+if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+    // default to current working directory on windows
+    $configFile = $args->getOpt('config', getcwd() . '/phpdns.json');
+    $storageDirectory = $args->getOpt('storage', getcwd());
+} else {
+    // default to /etc/phpdns.json and /etc/phpdnsserver if not on windows
+    $configFile = $args->getOpt('config', '/etc/phpdns.json');
+    $storageDirectory = $args->getOpt('storage', '/etc/phpdnserver');
+}
 
-// Parse and return cli args.
+// initialize the configuration
+$config = new yswery\DNS\Config\FileConfig($configFile);
+try {
+    $config->load();
+
+    if ($config->has('host')) {
+        $host = $config->get('host');
+    }
+
+    if ($config->has('port')) {
+        $port = $config->get('port');
+    }
+
+    if ($config->has('storage')) {
+        $storageDirectory = $config->get('storage');
+    }
+} catch (\yswery\DNS\Exception\ConfigFileNotFoundException $e) {
+    echo $e->getMessage();
+}
 
 // Create the eventDispatcher and add the event subscribers
 $eventDispatcher = new \Symfony\Component\EventDispatcher\EventDispatcher();
 $eventDispatcher->addSubscriber(new \yswery\DNS\Event\Subscriber\EchoLogger());
 
-// Create a new instance of Server class
-$server = new yswery\DNS\Server(null, $eventDispatcher, true, $host, $port);
+try {
+    // Create a new instance of Server class
+    $server = new yswery\DNS\Server(null, $eventDispatcher, $config, $storageDirectory, true, $host, $port);
 
-// Start DNS server
-$server->run();
+    // Start DNS server
+    $server->run();
+} catch (\Exception $e) {
+    echo $e->getMessage();
+}

--- a/bin/PhpDnsServer.php
+++ b/bin/PhpDnsServer.php
@@ -1,0 +1,30 @@
+<?php
+
+require '../vendor/autoload.php';
+
+use Garden\Cli\Cli;
+
+$cli = new Cli();
+
+$cli
+    ->opt('bind:b', 'Bind to a specific ip interface', false)
+    ->opt('port:p', 'specify the port to bind to', false);
+
+$args = $cli->parse($argv, true);
+
+// defaults
+$host = $args->getOpt('bind', '0.0.0.0');
+$port = $args->getOpt('port', 53);
+
+
+// Parse and return cli args.
+
+// Create the eventDispatcher and add the event subscribers
+$eventDispatcher = new \Symfony\Component\EventDispatcher\EventDispatcher();
+$eventDispatcher->addSubscriber(new \yswery\DNS\Event\Subscriber\EchoLogger());
+
+// Create a new instance of Server class
+$server = new yswery\DNS\Server(null, $eventDispatcher, true, $host, $port);
+
+// Start DNS server
+$server->run();

--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,7 @@
     },
     "scripts": {
         "build-server": "box compile -c server.box.json",
-        "build-console": "box compile -c console.box.json"
+        "build-console": "box compile -c console.box.json",
+        "build-installer": "box compile -c installer.box.json"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
     "description": "A DNS server implementation in pure PHP.",
     "require-dev": {
         "phpunit/phpunit": "~7.3",
-        "php-coveralls/php-coveralls": "~2.1"
+        "php-coveralls/php-coveralls": "~2.1",
+        "bamarni/composer-bin-plugin": "^1.3"
     },
     "license": "MIT",
     "authors": [
@@ -31,7 +32,10 @@
         "ext-json": "~1.0",
         "ext-simplexml": "*",
         "symfony/event-dispatcher": "~4.0",
-        "psr/log": "^1.0"
+        "psr/log": "^1.0",
+        "symfony/filesystem": "^4.3",
+        "symfony/console": "^4.3",
+        "vanilla/garden-cli": "^2.2"
     },
     "autoload": {
         "psr-4": {
@@ -42,5 +46,9 @@
         "psr-4": {
             "yswery\\DNS\\Tests\\": "tests/"
         }
+    },
+    "scripts": {
+        "build-server": "box compile -c server.box.json",
+        "build-console": "box compile -c console.box.json"
     }
 }

--- a/console.box.json
+++ b/console.box.json
@@ -1,0 +1,13 @@
+{
+  "chmod": "0755",
+  "main": "bin/PhpDnsConsole.php",
+  "output": "bin/phpdnscli.phar",
+  "directories": ["src"],
+  "finder": [
+    {
+      "name": "*.php",
+      "exclude": ["test", "tests"],
+      "in": "vendor"
+    }
+  ],    "stub": true
+}

--- a/installer.box.json
+++ b/installer.box.json
@@ -1,0 +1,13 @@
+{
+  "chmod": "0755",
+  "main": "bin/PhpDnsInstaller.php",
+  "output": "bin/phpdnsinstaller.phar",
+  "finder": [
+    {
+      "name": "*.php",
+      "exclude": ["test", "tests"],
+      "in": "vendor"
+    }
+  ],
+  "stub": true
+}

--- a/server.box.json
+++ b/server.box.json
@@ -1,0 +1,13 @@
+{
+  "chmod": "0755",
+  "main": "bin/PhpDnsServer.php",
+  "output": "bin/phpdnsserver.phar",
+  "directories": ["src"],
+  "finder": [
+    {
+      "name": "*.php",
+      "exclude": ["test", "tests"],
+      "in": "vendor"
+    }
+  ],    "stub": true
+}

--- a/src/Config/FileConfig.php
+++ b/src/Config/FileConfig.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of PHP DNS Server.
+ *
+ * (c) Yif Swery <yiftachswr@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace yswery\DNS\Config;
 
 use yswery\DNS\Exception\ConfigFileNotFoundException;
@@ -31,7 +40,7 @@ class FileConfig
             $data = file_get_contents($this->configFile);
             $this->config = json_decode($data);
         } else {
-            throw new ConfigFileNotFoundException("Config file not found.");
+            throw new ConfigFileNotFoundException('Config file not found.');
         }
     }
 

--- a/src/Config/FileConfig.php
+++ b/src/Config/FileConfig.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace yswery\DNS\Config;
+
+use yswery\DNS\Exception\ConfigFileNotFoundException;
+
+class FileConfig
+{
+    /**
+     * @var string
+     */
+    protected $configFile;
+
+    /**
+     * @var object
+     */
+    protected $config;
+
+    public function __construct(string $configFile)
+    {
+        $this->configFile = $configFile;
+    }
+
+    /**
+     * @throws ConfigFileNotFoundException
+     */
+    public function load()
+    {
+        // make sure the file exists before loading the config
+        if (file_exists($this->configFile)) {
+            $data = file_get_contents($this->configFile);
+            $this->config = json_decode($data);
+        } else {
+            throw new ConfigFileNotFoundException("Config file not found.");
+        }
+    }
+
+    public function save()
+    {
+        file_put_contents($this->configFile, json_encode($this->config));
+    }
+
+    public function get($key, $default = null)
+    {
+        if (isset($this->config->{$key})) {
+            return $this->config->{$key};
+        }
+
+        return $default;
+    }
+
+    public function set(array $data)
+    {
+        $configObject = new RecursiveArrayObject($this->config);
+        $configArray = $configObject->getArrayCopy();
+
+        //$origional = json_decode(json_encode($this->config), true);
+        $new = array_merge($configArray, $data);
+
+        $this->config = json_decode(json_encode($new), false);
+    }
+
+    public function has($key)
+    {
+        return isset($this->config->{$key});
+    }
+}

--- a/src/Config/RecursiveArrayObject.php
+++ b/src/Config/RecursiveArrayObject.php
@@ -1,21 +1,31 @@
 <?php
 
+/*
+ * This file is part of PHP DNS Server.
+ *
+ * (c) Yif Swery <yiftachswr@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace yswery\DNS\Config;
 
 use ArrayObject;
 
 class RecursiveArrayObject extends ArrayObject
 {
-    function getArrayCopy()
+    public function getArrayCopy()
     {
         $resultArray = parent::getArrayCopy();
-        foreach($resultArray as $key => $val) {
+        foreach ($resultArray as $key => $val) {
             if (!is_object($val)) {
                 continue;
             }
             $o = new RecursiveArrayObject($val);
             $resultArray[$key] = $o->getArrayCopy();
         }
+
         return $resultArray;
     }
 }

--- a/src/Config/RecursiveArrayObject.php
+++ b/src/Config/RecursiveArrayObject.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace yswery\DNS\Config;
+
+use ArrayObject;
+
+class RecursiveArrayObject extends ArrayObject
+{
+    function getArrayCopy()
+    {
+        $resultArray = parent::getArrayCopy();
+        foreach($resultArray as $key => $val) {
+            if (!is_object($val)) {
+                continue;
+            }
+            $o = new RecursiveArrayObject($val);
+            $resultArray[$key] = $o->getArrayCopy();
+        }
+        return $resultArray;
+    }
+}

--- a/src/Console/CommandServer.php
+++ b/src/Console/CommandServer.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of PHP DNS Server.
+ *
+ * (c) Yif Swery <yiftachswr@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace yswery\DNS\Console;
 
 use Symfony\Component\Console\Application;

--- a/src/Console/CommandServer.php
+++ b/src/Console/CommandServer.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace yswery\DNS\Console;
+
+use Symfony\Component\Console\Application;
+use yswery\DNS\Console\Commands\VersionCommand;
+use yswery\DNS\Server;
+
+class CommandServer extends Application
+{
+    public function __construct()
+    {
+        parent::__construct('PhpDnsServer', Server::VERSION);
+
+        $this->registerCommands();
+    }
+
+    protected function registerCommands()
+    {
+        $this->add(new VersionCommand());
+    }
+}

--- a/src/Console/Commands/VersionCommand.php
+++ b/src/Console/Commands/VersionCommand.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace yswery\DNS\Console\Commands;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use yswery\DNS\Server;
+
+class VersionCommand extends Command
+{
+    protected static $defaultName = "version";
+
+    protected function configure()
+    {
+        $this->setDescription('Shows the current PhpDnsServer version')
+            ->setHelp('Shows the current PhpDnsServer version');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln('PowerDnsServer version '.Server::VERSION);
+    }
+}

--- a/src/Console/Commands/VersionCommand.php
+++ b/src/Console/Commands/VersionCommand.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of PHP DNS Server.
+ *
+ * (c) Yif Swery <yiftachswr@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace yswery\DNS\Console\Commands;
 
 use Symfony\Component\Console\Command\Command;
@@ -9,7 +18,7 @@ use yswery\DNS\Server;
 
 class VersionCommand extends Command
 {
-    protected static $defaultName = "version";
+    protected static $defaultName = 'version';
 
     protected function configure()
     {

--- a/src/Exception/ConfigFileNotFoundException.php
+++ b/src/Exception/ConfigFileNotFoundException.php
@@ -1,10 +1,18 @@
 <?php
 
+/*
+ * This file is part of PHP DNS Server.
+ *
+ * (c) Yif Swery <yiftachswr@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace yswery\DNS\Exception;
 
 use Exception;
 
 class ConfigFileNotFoundException extends Exception
 {
-
 }

--- a/src/Exception/ConfigFileNotFoundException.php
+++ b/src/Exception/ConfigFileNotFoundException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace yswery\DNS\Exception;
+
+use Exception;
+
+class ConfigFileNotFoundException extends Exception
+{
+
+}

--- a/src/Exception/InvalidZoneFileException.php
+++ b/src/Exception/InvalidZoneFileException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace yswery\DNS\Exception;
+
+use RuntimeException;
+
+class InvalidZoneFileException extends RuntimeException
+{
+
+}

--- a/src/Exception/InvalidZoneFileException.php
+++ b/src/Exception/InvalidZoneFileException.php
@@ -1,10 +1,18 @@
 <?php
 
+/*
+ * This file is part of PHP DNS Server.
+ *
+ * (c) Yif Swery <yiftachswr@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace yswery\DNS\Exception;
 
 use RuntimeException;
 
 class InvalidZoneFileException extends RuntimeException
 {
-
 }

--- a/src/Exception/ZoneFileNotFoundException.php
+++ b/src/Exception/ZoneFileNotFoundException.php
@@ -1,10 +1,18 @@
 <?php
 
+/*
+ * This file is part of PHP DNS Server.
+ *
+ * (c) Yif Swery <yiftachswr@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace yswery\DNS\Exception;
 
 use RuntimeException;
 
 class ZoneFileNotFoundException extends RuntimeException
 {
-
 }

--- a/src/Exception/ZoneFileNotFoundException.php
+++ b/src/Exception/ZoneFileNotFoundException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace yswery\DNS\Exception;
+
+use RuntimeException;
+
+class ZoneFileNotFoundException extends RuntimeException
+{
+
+}

--- a/src/Filesystem/FilesystemManager.php
+++ b/src/Filesystem/FilesystemManager.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace yswery\DNS\Filesystem;
+
+use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use yswery\DNS\Resolver\JsonFileSystemResolver;
+
+class FilesystemManager
+{
+    /**
+     * @var Filesystem
+     */
+    protected $filesystem;
+
+    /**
+     * @var string
+     */
+    protected $basePath;
+
+    /**
+     * @var string
+     */
+    protected $zonePath;
+
+    public function __construct($basePath = null, $zonePath = null)
+    {
+        if ($basePath)
+        {
+            $this->setBasePath($basePath);
+        }
+
+        if ($zonePath)
+        {
+            $this->setZonePath($zonePath);
+        }
+
+
+        $this->registerFilesystem();
+    }
+
+    protected function registerFilesystem()
+    {
+        $this->filesystem = new Filesystem();
+
+        // make sure our directories exist
+        if (!$this->filesystem->exists($this->zonePath()))
+        {
+            try {
+                $this->filesystem->mkdir($this->zonePath(), 0700);
+            } catch (IOExceptionInterface $e) {
+                // todo: implement logging functions
+            }
+
+        }
+
+    }
+
+    public function setBasePath($basePath)
+    {
+        $this->basePath = rtrim($basePath, '\/');
+        return $this;
+    }
+
+    public function basePath()
+    {
+        return $this->basePath;
+    }
+
+    public function setZonePath($zonePath)
+    {
+        $this->zonePath = rtrim($zonePath, '\/');
+        return $this;
+    }
+
+    public function zonePath()
+    {
+        return $this->zonePath ?: $this->basePath.DIRECTORY_SEPARATOR.'zones';
+    }
+
+    /**
+     * @param string $zone
+     * @return JsonFileSystemResolver
+     * @throws \yswery\DNS\UnsupportedTypeException
+     */
+    public function getZone(string $zone)
+    {
+        $zoneFile = $this->basePath().DIRECTORY_SEPARATOR.$zone.'.json';
+        return new JsonFileSystemResolver($zoneFile);
+    }
+}

--- a/src/Filesystem/FilesystemManager.php
+++ b/src/Filesystem/FilesystemManager.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of PHP DNS Server.
+ *
+ * (c) Yif Swery <yiftachswr@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace yswery\DNS\Filesystem;
 
 use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
@@ -25,16 +34,13 @@ class FilesystemManager
 
     public function __construct($basePath = null, $zonePath = null)
     {
-        if ($basePath)
-        {
+        if ($basePath) {
             $this->setBasePath($basePath);
         }
 
-        if ($zonePath)
-        {
+        if ($zonePath) {
             $this->setZonePath($zonePath);
         }
-
 
         $this->registerFilesystem();
     }
@@ -44,21 +50,19 @@ class FilesystemManager
         $this->filesystem = new Filesystem();
 
         // make sure our directories exist
-        if (!$this->filesystem->exists($this->zonePath()))
-        {
+        if (!$this->filesystem->exists($this->zonePath())) {
             try {
                 $this->filesystem->mkdir($this->zonePath(), 0700);
             } catch (IOExceptionInterface $e) {
                 // todo: implement logging functions
             }
-
         }
-
     }
 
     public function setBasePath($basePath)
     {
         $this->basePath = rtrim($basePath, '\/');
+
         return $this;
     }
 
@@ -70,6 +74,7 @@ class FilesystemManager
     public function setZonePath($zonePath)
     {
         $this->zonePath = rtrim($zonePath, '\/');
+
         return $this;
     }
 
@@ -80,12 +85,15 @@ class FilesystemManager
 
     /**
      * @param string $zone
+     *
      * @return JsonFileSystemResolver
+     *
      * @throws \yswery\DNS\UnsupportedTypeException
      */
     public function getZone(string $zone)
     {
         $zoneFile = $this->basePath().DIRECTORY_SEPARATOR.$zone.'.json';
+
         return new JsonFileSystemResolver($zoneFile);
     }
 }

--- a/src/Resolver/AbstractResolver.php
+++ b/src/Resolver/AbstractResolver.php
@@ -28,6 +28,11 @@ abstract class AbstractResolver implements ResolverInterface
     protected $isAuthoritative;
 
     /**
+     * @var bool
+     */
+    protected $supportsSaving = false;
+
+    /**
      * @var ResourceRecord[]
      */
     protected $resourceRecords = [];
@@ -74,6 +79,14 @@ abstract class AbstractResolver implements ResolverInterface
     public function isAuthority($domain): bool
     {
         return $this->isAuthoritative;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function supportsSaving()
+    {
+        return $this->supportsSaving;
     }
 
     /**

--- a/src/Resolver/AbstractResolver.php
+++ b/src/Resolver/AbstractResolver.php
@@ -82,7 +82,7 @@ abstract class AbstractResolver implements ResolverInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function supportsSaving()
     {

--- a/src/Resolver/JsonFileSystemResolver.php
+++ b/src/Resolver/JsonFileSystemResolver.php
@@ -39,7 +39,7 @@ class JsonFileSystemResolver extends AbstractResolver
      * JsonResolver constructor.
      *
      * @param FilesystemManager $filesystemManager
-     * @param int   $defaultTtl
+     * @param int               $defaultTtl
      *
      * @throws UnsupportedTypeException
      */
@@ -50,9 +50,8 @@ class JsonFileSystemResolver extends AbstractResolver
         $this->filesystemManager = $filesystemManager;
         $this->defaultTtl = $defaultTtl;
 
-        $zones = glob($filesystemManager->zonePath()."/*.json");
-        foreach ($zones as $file)
-        {
+        $zones = glob($filesystemManager->zonePath().'/*.json');
+        foreach ($zones as $file) {
             $zone = json_decode(file_get_contents($file), true);
             $resourceRecords = $this->isLegacyFormat($zone) ? $this->processLegacyZone($zone) : $this->processZone($zone);
             $this->addZone($resourceRecords);
@@ -60,31 +59,31 @@ class JsonFileSystemResolver extends AbstractResolver
     }
 
     /**
-     * Load a zone file
+     * Load a zone file.
      *
      * @param string $file
+     *
      * @throws UnsupportedTypeException
      * @throws ZoneFileNotFoundException
      */
-    public function loadZone($file) {
-        if (file_exists($file))
-        {
+    public function loadZone($file)
+    {
+        if (file_exists($file)) {
             $zone = json_decode(file_get_contents($file), true);
             $resourceRecords = $this->isLegacyFormat($zone) ? $this->processLegacyZone($zone) : $this->processZone($zone);
             $this->addZone($resourceRecords);
         } else {
-            throw new ZoneFileNotFoundException("The zone file could not be found");
+            throw new ZoneFileNotFoundException('The zone file could not be found');
         }
     }
 
-
     /**
-     * Saves the zone to a .json file
+     * Saves the zone to a .json file.
+     *
      * @param string $zone
      */
     public function saveZone($zone)
     {
-
     }
 
     /**

--- a/src/Resolver/JsonFileSystemResolver.php
+++ b/src/Resolver/JsonFileSystemResolver.php
@@ -1,0 +1,163 @@
+<?php
+
+/*
+ * This file is part of PHP DNS Server.
+ *
+ * (c) Yif Swery <yiftachswr@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace yswery\DNS\Resolver;
+
+use yswery\DNS\ClassEnum;
+use yswery\DNS\Exception\ZoneFileNotFoundException;
+use yswery\DNS\Filesystem\FilesystemManager;
+use yswery\DNS\RecordTypeEnum;
+use yswery\DNS\ResourceRecord;
+use yswery\DNS\UnsupportedTypeException;
+
+class JsonFileSystemResolver extends AbstractResolver
+{
+    /**
+     * @var int
+     */
+    protected $defaultClass = ClassEnum::INTERNET;
+
+    /**
+     * @var FilesystemManager
+     */
+    protected $filesystemManager;
+
+    /**
+     * @var int
+     */
+    protected $defaultTtl;
+
+    /**
+     * JsonResolver constructor.
+     *
+     * @param FilesystemManager $filesystemManager
+     * @param int   $defaultTtl
+     *
+     * @throws UnsupportedTypeException
+     */
+    public function __construct(FilesystemManager $filesystemManager, $defaultTtl = 300)
+    {
+        $this->isAuthoritative = true;
+        $this->allowRecursion = false;
+        $this->filesystemManager = $filesystemManager;
+        $this->defaultTtl = $defaultTtl;
+
+        $zones = glob($filesystemManager->zonePath()."/*.json");
+        foreach ($zones as $file)
+        {
+            $zone = json_decode(file_get_contents($file), true);
+            $resourceRecords = $this->isLegacyFormat($zone) ? $this->processLegacyZone($zone) : $this->processZone($zone);
+            $this->addZone($resourceRecords);
+        }
+    }
+
+    /**
+     * Load a zone file
+     *
+     * @param string $file
+     * @throws UnsupportedTypeException
+     * @throws ZoneFileNotFoundException
+     */
+    public function loadZone($file) {
+        if (file_exists($file))
+        {
+            $zone = json_decode(file_get_contents($file), true);
+            $resourceRecords = $this->isLegacyFormat($zone) ? $this->processLegacyZone($zone) : $this->processZone($zone);
+            $this->addZone($resourceRecords);
+        } else {
+            throw new ZoneFileNotFoundException("The zone file could not be found");
+        }
+    }
+
+
+    /**
+     * Saves the zone to a .json file
+     * @param string $zone
+     */
+    public function saveZone($zone)
+    {
+
+    }
+
+    /**
+     * @param array $zone
+     *
+     * @return ResourceRecord[]
+     *
+     * @throws UnsupportedTypeException
+     */
+    protected function processZone(array $zone): array
+    {
+        $parent = rtrim($zone['domain'], '.').'.';
+        $defaultTtl = $zone['default-ttl'];
+        $rrs = $zone['resource-records'];
+        $resourceRecords = [];
+
+        foreach ($rrs as $rr) {
+            $name = $rr['name'] ?? $parent;
+            $class = isset($rr['class']) ? ClassEnum::getClassFromName($rr['class']) : $this->defaultClass;
+
+            $resourceRecords[] = (new ResourceRecord())
+                ->setName($this->handleName($name, $parent))
+                ->setClass($class)
+                ->setType($type = RecordTypeEnum::getTypeFromName($rr['type']))
+                ->setTtl($rr['ttl'] ?? $defaultTtl)
+                ->setRdata($this->extractRdata($rr, $type, $parent));
+        }
+
+        return $resourceRecords;
+    }
+
+    /**
+     * Determine if a $zone is in the legacy format.
+     *
+     * @param array $zone
+     *
+     * @return bool
+     */
+    protected function isLegacyFormat(array $zone): bool
+    {
+        $keys = array_map(function ($value) {
+            return strtolower($value);
+        }, array_keys($zone));
+
+        return
+            (false === array_search('domain', $keys, true)) ||
+            (false === array_search('resource-records', $keys, true));
+    }
+
+    /**
+     * @param array $zones
+     *
+     * @return array
+     */
+    protected function processLegacyZone(array $zones): array
+    {
+        $resourceRecords = [];
+        foreach ($zones as $domain => $types) {
+            $domain = rtrim($domain, '.').'.';
+            foreach ($types as $type => $data) {
+                $data = (array) $data;
+                $type = RecordTypeEnum::getTypeFromName($type);
+                foreach ($data as $rdata) {
+                    $resourceRecords[] = (new ResourceRecord())
+                        ->setName($domain)
+                        ->setType($type)
+                        ->setClass($this->defaultClass)
+                        ->setTtl($this->defaultTtl)
+                        ->setRdata($rdata);
+                }
+            }
+        }
+
+        return $resourceRecords;
+    }
+}

--- a/src/Server.php
+++ b/src/Server.php
@@ -72,6 +72,11 @@ class Server
     private $useFilesystem;
 
     /**
+     * @var bool
+     */
+    private $isWindows;
+
+    /**
      * Server constructor.
      *
      * @param ResolverInterface        $resolver
@@ -93,7 +98,16 @@ class Server
         $this->port = $port;
         $this->ip = $ip;
 
-        // setup file system manger
+        // detect os and setup file manager, default to working directory on windows
+        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+            $this->isWindows = true;
+            $this->filesystemManager = new FilesystemManager(getcwd());
+        } else {
+            // default to /etc/phpdnsserver on unix
+            $this->isWindows = false;
+            $this->filesystemManager = new FilesystemManager("/etc/phpdnsserver/");
+        }
+
         $this->filesystemManager = new FilesystemManager(getcwd());
         $this->useFilesystem = $useFilesystem;
 

--- a/src/Server.php
+++ b/src/Server.php
@@ -14,8 +14,6 @@ namespace yswery\DNS;
 use React\Datagram\Socket;
 use React\Datagram\SocketInterface;
 use React\EventLoop\LoopInterface;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\Event;
 use yswery\DNS\Config\FileConfig;
@@ -32,10 +30,11 @@ use yswery\DNS\Filesystem\FilesystemManager;
 class Server
 {
     /**
-     * The version of PhpDnsServer we are running
+     * The version of PhpDnsServer we are running.
+     *
      * @var string
      */
-    const VERSION = "1.4.0";
+    const VERSION = '1.4.0';
 
     /**
      * @var EventDispatcherInterface
@@ -95,7 +94,7 @@ class Server
      *
      * @throws \Exception
      */
-    public function __construct(?ResolverInterface $resolver = null, ?EventDispatcherInterface $dispatcher = null, ?FileConfig $config = null, string $storageDirectory = null,  bool $useFilesystem = false,  string $ip = '0.0.0.0', int $port = 53)
+    public function __construct(?ResolverInterface $resolver = null, ?EventDispatcherInterface $dispatcher = null, ?FileConfig $config = null, string $storageDirectory = null, bool $useFilesystem = false, string $ip = '0.0.0.0', int $port = 53)
     {
         if (!function_exists('socket_create') || !extension_loaded('sockets')) {
             throw new \Exception('Socket extension or socket_create() function not found.');
@@ -109,7 +108,7 @@ class Server
         $this->useFilesystem = $useFilesystem;
 
         // detect os
-        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+        if ('WIN' === strtoupper(substr(PHP_OS, 0, 3))) {
             $this->isWindows = true;
         } else {
             $this->isWindows = false;
@@ -130,7 +129,6 @@ class Server
             $this->dispatch(Events::SERVER_START_FAIL, new ServerExceptionEvent($exception));
         });
     }
-
 
     /**
      * Start the server.
@@ -176,7 +174,6 @@ class Server
     {
         $message = Decoder::decodeMessage($buffer);
         $this->dispatch(Events::QUERY_RECEIVE, new QueryReceiveEvent($message));
-
 
         $responseMessage = clone $message;
         $responseMessage->getHeader()

--- a/src/Server.php
+++ b/src/Server.php
@@ -88,14 +88,14 @@ class Server
      * @param ResolverInterface        $resolver
      * @param EventDispatcherInterface $dispatcher
      * @param FileConfig               $config
-     * @param string                   $storageDirectory
+     * @param string|null              $storageDirectory
      * @param bool                     $useFilesystem
      * @param string                   $ip
      * @param int                      $port
      *
      * @throws \Exception
      */
-    public function __construct(?ResolverInterface $resolver = null, ?EventDispatcherInterface $dispatcher = null, ?FileConfig $config = null, string $storageDirectory,  bool $useFilesystem = false,  string $ip = '0.0.0.0', int $port = 53)
+    public function __construct(?ResolverInterface $resolver = null, ?EventDispatcherInterface $dispatcher = null, ?FileConfig $config = null, string $storageDirectory = null,  bool $useFilesystem = false,  string $ip = '0.0.0.0', int $port = 53)
     {
         if (!function_exists('socket_create') || !extension_loaded('sockets')) {
             throw new \Exception('Socket extension or socket_create() function not found.');
@@ -106,20 +106,18 @@ class Server
         $this->config = $config;
         $this->port = $port;
         $this->ip = $ip;
-
-        // detect os and setup file manager, default to working directory on windows
+        $this->useFilesystem = $useFilesystem;
+        
+        // detect os
         if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
             $this->isWindows = true;
-            $this->filesystemManager = new FilesystemManager($storageDirectory);
         } else {
-            // default to /etc/phpdnsserver on unix
             $this->isWindows = false;
-            $this->filesystemManager = new FilesystemManager($storageDirectory);
         }
 
-        $this->useFilesystem = $useFilesystem;
-
+        // only register filesystem if we want to use it
         if ($useFilesystem) {
+            $this->filesystemManager = new FilesystemManager($storageDirectory);
             $this->resolver = new JsonFileSystemResolver($this->filesystemManager);
         }
 

--- a/src/Server.php
+++ b/src/Server.php
@@ -107,7 +107,7 @@ class Server
         $this->port = $port;
         $this->ip = $ip;
         $this->useFilesystem = $useFilesystem;
-        
+
         // detect os
         if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
             $this->isWindows = true;

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -51,7 +51,7 @@ class ServerTest extends TestCase
             $xmlResolver,
         ]);
 
-        $this->server = new Server($resolver, new EventDispatcher());
+        $this->server = new Server($resolver, new EventDispatcher(), null, null, false);
     }
 
     /**

--- a/vendor-bin/box/composer.json
+++ b/vendor-bin/box/composer.json
@@ -1,0 +1,5 @@
+{
+    "require-dev": {
+        "humbug/box": "^3.8"
+    }
+}


### PR DESCRIPTION
Adds the beginning of a cli interface for PhpDnsServer, and a filesystem config for loading all .json files from a zones directory. 

Some additional ideas, if php is running on linux or unix we could default to /etc/phpdnsserver/settings.json  or /etc/phpdns.conf for a config file
