### PR TITLE
Send an optional `client` parameter to resolvers

### DIFF
--- a/src/Resolver/AbstractResolver.php
+++ b/src/Resolver/AbstractResolver.php
@@ -45,7 +45,7 @@ abstract class AbstractResolver implements ResolverInterface
      *
      * @return array
      */
-    public function getAnswer(array $queries): array
+    public function getAnswer(array $queries, ?string $client = null): array
     {
         $answers = [];
         foreach ($queries as $query) {

--- a/src/Resolver/ResolverInterface.php
+++ b/src/Resolver/ResolverInterface.php
@@ -25,7 +25,7 @@ interface ResolverInterface
      *
      * @return ResourceRecord[]
      */
-    public function getAnswer(array $queries): array;
+    public function getAnswer(array $queries, ?string $client = null): array;
 
     /**
      * Returns true if resolver supports recursion.

--- a/src/Resolver/StackableResolver.php
+++ b/src/Resolver/StackableResolver.php
@@ -30,7 +30,7 @@ class StackableResolver implements ResolverInterface
      *
      * @return array
      */
-    public function getAnswer(array $question): array
+    public function getAnswer(array $question, ?string $client = null): array
     {
         foreach ($this->resolvers as $resolver) {
             $answer = $resolver->getAnswer($question);

--- a/src/Resolver/SystemResolver.php
+++ b/src/Resolver/SystemResolver.php
@@ -39,7 +39,7 @@ class SystemResolver extends AbstractResolver
      *
      * @throws UnsupportedTypeException
      */
-    public function getAnswer(array $queries): array
+    public function getAnswer(array $queries, ?string $client = null): array
     {
         $answer = [];
         foreach ($queries as $query) {

--- a/src/Server.php
+++ b/src/Server.php
@@ -102,7 +102,7 @@ class Server
     {
         try {
             $this->dispatch(Events::MESSAGE, new MessageEvent($socket, $address, $message));
-            $socket->send($this->handleQueryFromStream($message), $address);
+            $socket->send($this->handleQueryFromStream($message, $address), $address);
         } catch (\Exception $exception) {
             $this->dispatch(Events::SERVER_EXCEPTION, new ServerExceptionEvent($exception));
         }
@@ -117,7 +117,7 @@ class Server
      *
      * @throws UnsupportedTypeException
      */
-    public function handleQueryFromStream(string $buffer): string
+    public function handleQueryFromStream(string $buffer, ?string $client = null): string
     {
         $message = Decoder::decodeMessage($buffer);
         $this->dispatch(Events::QUERY_RECEIVE, new QueryReceiveEvent($message));
@@ -129,7 +129,7 @@ class Server
             ->setAuthoritative($this->isAuthoritative($message->getQuestions()));
 
         try {
-            $answers = $this->resolver->getAnswer($responseMessage->getQuestions());
+            $answers = $this->resolver->getAnswer($responseMessage->getQuestions(), $client);
             $responseMessage->setAnswers($answers);
             $this->needsAdditionalRecords($responseMessage);
             $this->dispatch(Events::QUERY_RESPONSE, new QueryResponseEvent($responseMessage));

--- a/tests/DummyResolver.php
+++ b/tests/DummyResolver.php
@@ -32,7 +32,7 @@ class DummyResolver implements ResolverInterface
      *
      * @return array
      */
-    public function getAnswer(array $queries): array
+    public function getAnswer(array $queries, ?string $client = null): array
     {
         $q = $queries[0];
 


### PR DESCRIPTION
For discussion - can we send the client (address making the request) down to the resolver?

This would allow for complex resolvers to be created that have different rules per-client.
